### PR TITLE
Fix crash when calling StackTrace.fromError

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function init(smap) {
 
   var originalHandler = global.ErrorUtils.getGlobalHandler();
   function errorHandler(e) {
-    StackTrace.fromError(e).then((x)=>Crashlytics.recordCustomExceptionName(e.message, e.message, x.map(row=>{
+    StackTrace.fromError(e, {offline:true}).then((x)=>Crashlytics.recordCustomExceptionName(e.message, e.message, x.map(row=>{
       const loc = mapper(row);
       return {
         fileName: loc.source || row.fileName,


### PR DESCRIPTION
StackTrace.fromError tries to get the js file from the network. By setting offline option to true we avoid that call.
For more details: https://github.com/facebook/react-native/issues/7998#issuecomment-232013128